### PR TITLE
feat: add map_page

### DIFF
--- a/src/components/Maptest.tsx
+++ b/src/components/Maptest.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { loadKakaoScript } from '../utils/loadKakaoScript';
 import { API_URL } from '../constants/api';
 import { accessToken } from '../apis';
 
 const MapTest = () => {
-  const hasInitialized = useRef(false);
-
   useEffect(() => {
     const initializeMap = async () => {
       try {
@@ -93,7 +91,9 @@ const MapTest = () => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const renderMarkers = (map: any, houses: any[]) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   houses.forEach((house: any) => {
     const position = new window.kakao.maps.LatLng(
       house.latitude,

--- a/src/components/Maptest.tsx
+++ b/src/components/Maptest.tsx
@@ -1,24 +1,51 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { loadKakaoScript } from '../utils/loadKakaoScript';
 import { API_URL } from '../constants/api';
-import { accessToken } from '../apis'; // accessToken 함수 가져와야 함
+import { accessToken } from '../apis';
 
 const MapTest = () => {
+  const hasInitialized = useRef(false);
+
   useEffect(() => {
-    loadKakaoScript()
-      .then(() => {
-        window.kakao.maps.load(() => {
+    const initializeMap = async () => {
+      try {
+        await loadKakaoScript();
+        window.kakao.maps.load(async () => {
           const container = document.getElementById('map');
           if (!container) return;
 
-          // 그냥 일단 첫번째 값 집어넣어놨음, 나중에는 내 위치가 기준점이 되거나, 사용자가 선택한 곳이 기준점이 될 것
-          const center = new window.kakao.maps.LatLng(33.450701, 126.570667);
-          const options = {
+          const token = await accessToken();
+
+          const res = await fetch(
+            `${API_URL}/v1/houses/map?minLatitude=0&minLongitude=0&maxLatitude=90&maxLongitude=180`,
+            {
+              method: 'GET',
+              headers: {
+                'X-AUTH-TOKEN': token,
+              },
+            }
+          );
+
+          const data = await res.json();
+          const houses = data.results;
+
+          if (!Array.isArray(houses) || houses.length === 0) {
+            console.warn('받은 주택 리스트가 없습니다');
+            return;
+          }
+
+          const firstHouse = houses[0];
+          const center = new kakao.maps.LatLng(
+            firstHouse.latitude,
+            firstHouse.longitude
+          );
+
+          const map = new kakao.maps.Map(container, {
             center,
             level: 3,
-          };
+          });
 
-          const map = new window.kakao.maps.Map(container, options);
+          renderMarkers(map, houses);
 
           kakao.maps.event.addListener(map, 'idle', async () => {
             const bounds = map.getBounds();
@@ -43,82 +70,20 @@ const MapTest = () => {
 
               const data = await res.json();
               const houses = data.results;
+              if (!Array.isArray(houses)) return;
 
-              if (!Array.isArray(houses)) {
-                console.warn('받은 주택 리스트가 배열이 아닙니다:', data);
-                return;
-              }
-
-              if (houses.length > 0) {
-                const firstHouse = houses[0];
-                const newCenter = new kakao.maps.LatLng(
-                  firstHouse.latitude,
-                  firstHouse.longitude
-                );
-                map.setCenter(newCenter);
-              }
-
-              houses.forEach((house: any) => {
-                const position = new kakao.maps.LatLng(
-                  house.latitude,
-                  house.longitude
-                );
-
-                // 마커 생성
-                const marker = new kakao.maps.Marker({
-                  map,
-                  position,
-                });
-
-                // houseName을 표시할 인포윈도우 생성
-                const infowindow = new kakao.maps.InfoWindow({
-                  position,
-                  content: `<div style="padding:5px; font-size:12px;">${house.houseName}</div>`,
-                });
-
-                // 지도에 인포윈도우 표시
-                // infowindow.open(map, marker);
-              });
-
-              houses.forEach((house: any) => {
-                const position = new kakao.maps.LatLng(
-                  house.latitude,
-                  house.longitude
-                );
-
-                // 1. 마커 생성
-                const marker = new kakao.maps.Marker({
-                  map,
-                  position,
-                  // marker 이미지를 커스텀 하고 싶다면 여기에 image로 박아야 할 듯
-                });
-
-                // 2. 커스텀 오버레이 생성 (마커 위에 텍스트)
-                const overlay = new kakao.maps.CustomOverlay({
-                  map,
-                  position,
-                  content: `
-      <div style="
-        background: white;
-        font-size: 12px;
-        font-weight: bold;
-        color: red;
-        margin-top: 32px;
-      ">
-        ${house.houseName}
-      </div>
-    `,
-                });
-              });
+              renderMarkers(map, houses);
             } catch (err) {
               console.error('지도 API 에러:', err);
             }
           });
         });
-      })
-      .catch((err) => {
+      } catch (err) {
         console.error('카카오 지도 로딩 실패:', err);
-      });
+      }
+    };
+
+    initializeMap();
   }, []);
 
   return (
@@ -126,6 +91,39 @@ const MapTest = () => {
       <div id='map' className='w-full h-full'></div>
     </div>
   );
+};
+
+const renderMarkers = (map: any, houses: any[]) => {
+  houses.forEach((house: any) => {
+    const position = new window.kakao.maps.LatLng(
+      house.latitude,
+      house.longitude
+    );
+
+    new window.kakao.maps.Marker({ map, position });
+
+    new window.kakao.maps.CustomOverlay({
+      map,
+      position,
+      yAnchor: 1.5,
+      content: `
+        <div style="
+          background: white;
+          font-size: 12px;
+          font-weight: bold;
+          color: red;
+          border: 1px solid red;
+          border-radius: 12px;
+          padding: 4px 8px;
+          white-space: nowrap;
+          box-shadow: 1px 1px 4px rgba(0,0,0,0.15);
+          margin-bottom: -32px;
+        ">
+          ${house.houseName}
+        </div>
+      `,
+    });
+  });
 };
 
 export default MapTest;

--- a/src/components/Maptest.tsx
+++ b/src/components/Maptest.tsx
@@ -1,14 +1,17 @@
-import { useEffect } from "react";
-import { loadKakaoScript } from "../utils/loadKakaoScript";
+import { useEffect } from 'react';
+import { loadKakaoScript } from '../utils/loadKakaoScript';
+import { API_URL } from '../constants/api';
+import { accessToken } from '../apis'; // accessToken 함수 가져와야 함
 
 const MapTest = () => {
   useEffect(() => {
     loadKakaoScript()
       .then(() => {
         window.kakao.maps.load(() => {
-          const container = document.getElementById("map");
+          const container = document.getElementById('map');
           if (!container) return;
 
+          // 그냥 일단 첫번째 값 집어넣어놨음, 나중에는 내 위치가 기준점이 되거나, 사용자가 선택한 곳이 기준점이 될 것
           const center = new window.kakao.maps.LatLng(33.450701, 126.570667);
           const options = {
             center,
@@ -17,42 +20,110 @@ const MapTest = () => {
 
           const map = new window.kakao.maps.Map(container, options);
 
-          // ✅ 여러 개 마커 좌표 정의
-          const positions = [
-            {
-              title: "카카오 본사",
-              latlng: new window.kakao.maps.LatLng(33.450705, 126.570677),
-            },
-            {
-              title: "어딘가1",
-              latlng: new window.kakao.maps.LatLng(33.451393, 126.570738),
-            },
-            {
-              title: "어딘가2",
-              latlng: new window.kakao.maps.LatLng(33.452291, 126.571239),
-            },
-          ];
+          kakao.maps.event.addListener(map, 'idle', async () => {
+            const bounds = map.getBounds();
+            const sw = bounds.getSouthWest();
+            const ne = bounds.getNorthEast();
 
-          // ✅ 반복해서 마커 찍기
-          positions.forEach((pos) => {
-            const marker = new window.kakao.maps.Marker({
-              map,
-              position: pos.latlng,
-              title: pos.title,
+            const query = new URLSearchParams({
+              minLatitude: String(sw.getLat()),
+              minLongitude: String(sw.getLng()),
+              maxLatitude: String(ne.getLat()),
+              maxLongitude: String(ne.getLng()),
             });
 
-            marker.setMap(map);
+            try {
+              const token = await accessToken();
+              const res = await fetch(`${API_URL}/v1/houses/map?${query}`, {
+                method: 'GET',
+                headers: {
+                  'X-AUTH-TOKEN': token,
+                },
+              });
+
+              const data = await res.json();
+              const houses = data.results;
+
+              if (!Array.isArray(houses)) {
+                console.warn('받은 주택 리스트가 배열이 아닙니다:', data);
+                return;
+              }
+
+              if (houses.length > 0) {
+                const firstHouse = houses[0];
+                const newCenter = new kakao.maps.LatLng(
+                  firstHouse.latitude,
+                  firstHouse.longitude
+                );
+                map.setCenter(newCenter);
+              }
+
+              houses.forEach((house: any) => {
+                const position = new kakao.maps.LatLng(
+                  house.latitude,
+                  house.longitude
+                );
+
+                // 마커 생성
+                const marker = new kakao.maps.Marker({
+                  map,
+                  position,
+                });
+
+                // houseName을 표시할 인포윈도우 생성
+                const infowindow = new kakao.maps.InfoWindow({
+                  position,
+                  content: `<div style="padding:5px; font-size:12px;">${house.houseName}</div>`,
+                });
+
+                // 지도에 인포윈도우 표시
+                // infowindow.open(map, marker);
+              });
+
+              houses.forEach((house: any) => {
+                const position = new kakao.maps.LatLng(
+                  house.latitude,
+                  house.longitude
+                );
+
+                // 1. 마커 생성
+                const marker = new kakao.maps.Marker({
+                  map,
+                  position,
+                  // marker 이미지를 커스텀 하고 싶다면 여기에 image로 박아야 할 듯
+                });
+
+                // 2. 커스텀 오버레이 생성 (마커 위에 텍스트)
+                const overlay = new kakao.maps.CustomOverlay({
+                  map,
+                  position,
+                  content: `
+      <div style="
+        background: white;
+        font-size: 12px;
+        font-weight: bold;
+        color: red;
+        margin-top: 32px;
+      ">
+        ${house.houseName}
+      </div>
+    `,
+                });
+              });
+            } catch (err) {
+              console.error('지도 API 에러:', err);
+            }
           });
         });
       })
       .catch((err) => {
-        console.error("카카오 지도 로딩 실패:", err);
+        console.error('카카오 지도 로딩 실패:', err);
       });
   }, []);
 
   return (
-    <div className="w-full bg-gray-200">
-      <div id="map" style={{ width: "300px", height: "700px" }}></div>
+    <div className='w-full h-screen'>
+      <div id='map' className='w-full h-full'></div>
     </div>
   );
 };

--- a/src/utils/loadKakaoScript.ts
+++ b/src/utils/loadKakaoScript.ts
@@ -5,8 +5,10 @@ export function loadKakaoScript(): Promise<void> {
       return;
     }
 
+    const apiKey = import.meta.env.VITE_KAKAO_MAP_API_KEY;
+
     const script = document.createElement('script');
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=e0bdd2802078f55b46ab9c2abc457170&autoload=false`;
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${apiKey}&autoload=false`;
     script.async = true;
     script.onload = () => {
       if (window.kakao && window.kakao.maps) {

--- a/src/utils/loadKakaoScript.ts
+++ b/src/utils/loadKakaoScript.ts
@@ -6,7 +6,7 @@ export function loadKakaoScript(): Promise<void> {
     }
 
     const script = document.createElement('script');
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=&autoload=false`;
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=e0bdd2802078f55b46ab9c2abc457170&autoload=false`;
     script.async = true;
     script.onload = () => {
       if (window.kakao && window.kakao.maps) {


### PR DESCRIPTION
## 📌 작업 개요
- 카카오 지도 연동 및 주택 위치 기반 마커 렌더링 구현

## ✅ 구현 내용
- 최초 로딩 시 전체 영역에 대해 주택 리스트 요청 후 첫 번째 위치로 지도 이동
- 지도 이동 시마다 범위 내 주택 리스트 재요청

## 🎯 협의할 내용
- 추후 사용자 위치 기반 초기 중심 설정 가능
  - 사용자 초기 설정 어디로 할 것인지?
- 디자인 관련해서 어떻게 할 것인지?